### PR TITLE
Add some missing requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,7 @@ requests==2.8.0
 requests-oauthlib==0.5.0
 oauthlib==1.0.3
 grappelli_safe==0.4.1
+filebrowser_safe==0.4.0
 Pillow==3.0.0
 beautifulsoup4==4.4.1
 https://github.com/stephenmcd/mezzanine/archive/master.tar.gz

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,9 @@ chardet==2.3.0
 requests==2.8.0
 requests-oauthlib==0.5.0
 oauthlib==1.0.3
+grappelli_safe==0.4.1
+Pillow==3.0.0
+beautifulsoup4==4.4.1
 https://github.com/stephenmcd/mezzanine/archive/master.tar.gz
 djangowind==0.14.1
 pep8==1.6.2


### PR DESCRIPTION
These requirements, which are in mezzanine's setup.py,
weren't throwing errors when they weren't required.

In particular, the grappelli_safe package is needed for mezzanine's
admin pages to display correctly.
